### PR TITLE
Couple few changes to make it better support for unicode inputs

### DIFF
--- a/VimIOS.xcodeproj/project.pbxproj
+++ b/VimIOS.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		46BEE8AB1BE090F400DF78C8 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 46BEBEED1BE0634800DF78C8 /* Main.storyboard */; };
 		46BEE8AC1BE090F400DF78C8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 46BEBEF21BE0634800DF78C8 /* LaunchScreen.storyboard */; };
 		46D16C9F1BFFCDF1005B5D08 /* VimMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46D16C9E1BFFCDF1005B5D08 /* VimMainView.swift */; };
+		CE32227A1EB731A500D27B31 /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE3222791EB731A500D27B31 /* CloudKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -2765,6 +2766,7 @@
 		46BEE8A91BE090B000DF78C8 /* VimAppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VimAppDelegate.swift; sourceTree = "<group>"; };
 		46BEE8F61BE09E8400DF78C8 /* VimIOS copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "VimIOS copy-Info.plist"; path = "/Users/Lars/vimIOS/VimIOS/VimIOS copy-Info.plist"; sourceTree = "<absolute>"; };
 		46D16C9E1BFFCDF1005B5D08 /* VimMainView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VimMainView.swift; sourceTree = "<group>"; };
+		CE3222791EB731A500D27B31 /* CloudKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CloudKit.framework; path = System/Library/Frameworks/CloudKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2772,6 +2774,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CE32227A1EB731A500D27B31 /* CloudKit.framework in Frameworks */,
 				468501D31BF6793700BFB8FF /* QuartzCore.framework in Frameworks */,
 				46BEE89E1BE06EDB00DF78C8 /* CoreGraphics.framework in Frameworks */,
 				46BEE89C1BE06ED600DF78C8 /* CoreText.framework in Frameworks */,
@@ -2822,6 +2825,7 @@
 				46BEBF081BE0634800DF78C8 /* VimIOSUITests */,
 				46BEBEE71BE0634800DF78C8 /* Products */,
 				46BEE8F61BE09E8400DF78C8 /* VimIOS copy-Info.plist */,
+				CE3222781EB731A500D27B31 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -6401,6 +6405,14 @@
 			path = xxd;
 			sourceTree = "<group>";
 		};
+		CE3222781EB731A500D27B31 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				CE3222791EB731A500D27B31 /* CloudKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -6469,9 +6481,12 @@
 				TargetAttributes = {
 					46BEBEE51BE0634800DF78C8 = {
 						CreatedOnToolsVersion = 7.1;
-						DevelopmentTeam = WB97F4TN5Z;
+						DevelopmentTeam = 7DR9P3926Q;
 						LastSwiftMigration = 0810;
 						SystemCapabilities = {
+							com.apple.Push = {
+								enabled = 1;
+							};
 							com.apple.iCloud = {
 								enabled = 1;
 							};
@@ -6767,6 +6782,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = VimIOS/VimIOS.entitlements;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 7DR9P3926Q;
 				GCC_PREFIX_HEADER = "${SRCROOT}/VimIOS/ios_prefix.h";
 				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/**";
@@ -6778,7 +6794,7 @@
 					"$(PROJECT_DIR)/vim/src/xpm/x64/lib",
 					"$(PROJECT_DIR)/vim/src/xpm/x86/lib",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = larki.VimIOS;
+				PRODUCT_BUNDLE_IDENTIFIER = gothice.VimIOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_DISABLE_SAFETY_CHECKS = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "VimIOS/VimIOS-Bridging-Header.h";
@@ -6792,7 +6808,8 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-                CODE_SIGN_ENTITLEMENTS = VimIOS/VimIOS.entitlements;
+				CODE_SIGN_ENTITLEMENTS = VimIOS/VimIOS.entitlements;
+				DEVELOPMENT_TEAM = 7DR9P3926Q;
 				GCC_PREFIX_HEADER = "${SRCROOT}/VimIOS/ios_prefix.h";
 				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/**";
@@ -6804,7 +6821,7 @@
 					"$(PROJECT_DIR)/vim/src/xpm/x64/lib",
 					"$(PROJECT_DIR)/vim/src/xpm/x86/lib",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = larki.VimIOS;
+				PRODUCT_BUNDLE_IDENTIFIER = gothice.VimIOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_DISABLE_SAFETY_CHECKS = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "";

--- a/VimIOS/Base.lproj/LaunchScreen.storyboard
+++ b/VimIOS/Base.lproj/LaunchScreen.storyboard
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -14,19 +18,17 @@
                         <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
                     </layoutGuides>
                     <view key="view" userInteractionEnabled="NO" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VIM for iOS" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="32" translatesAutoresizingMaskIntoConstraints="NO" id="yYw-NN-B0g">
-                                <rect key="frame" x="181.5" y="271" width="237" height="57.5"/>
-                                <animations/>
+                                <rect key="frame" x="69" y="305" width="237" height="57.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="48"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <animations/>
-                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="yYw-NN-B0g" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="28u-fb-KvE"/>
                             <constraint firstItem="yYw-NN-B0g" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="7db-Vu-SCk"/>

--- a/VimIOS/VimAppDelegate.swift
+++ b/VimIOS/VimAppDelegate.swift
@@ -32,6 +32,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             let file = "Inbox/"+url.lastPathComponent
             do_cmdline_cmd("tabedit \(file)".char)
             do_cmdline_cmd("redraw!".char)
+            do_cmdline_cmd("map <d-c> \"*y")
+            do_cmdline_cmd("map <d-v> \"*p")
             return true
         }
         return false

--- a/VimIOS/VimAppDelegate.swift
+++ b/VimIOS/VimAppDelegate.swift
@@ -66,6 +66,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         vimHelper(Int32(numberOfArguments),file)
     }
     
+    
+    
 }
 
 

--- a/VimIOS/VimIOS-Bridging-Header.h
+++ b/VimIOS/VimIOS-Bridging-Header.h
@@ -38,6 +38,7 @@ void gui_send_mouse_event(int button,int x,int y, int repeated_click, unsigned i
 
 int vim_setenv(const unsigned char *name, const unsigned char *value);
 int do_cmdline_cmd(const unsigned char *cmd);
+int State;
 
 void add_to_input_buf(const unsigned char  *s, int len);
 int getCTRLKeyCode(NSString * s);

--- a/VimIOS/VimIOS-Bridging-Header.h
+++ b/VimIOS/VimIOS-Bridging-Header.h
@@ -39,6 +39,10 @@ void gui_send_mouse_event(int button,int x,int y, int repeated_click, unsigned i
 int vim_setenv(const unsigned char *name, const unsigned char *value);
 int do_cmdline_cmd(const unsigned char *cmd);
 int State;
+CGFloat gui_fill_x(int col);
+CGFloat gui_fill_y(int row);
+CGFloat gui_text_x(int row);
+CGFloat gui_text_y(int row);
 
 void add_to_input_buf(const unsigned char  *s, int len);
 int getCTRLKeyCode(NSString * s);

--- a/VimIOS/VimIOS.entitlements
+++ b/VimIOS/VimIOS.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
 		<string>iCloud.$(CFBundleIdentifier)</string>
@@ -9,6 +11,7 @@
 	<key>com.apple.developer.icloud-services</key>
 	<array>
 		<string>CloudDocuments</string>
+		<string>CloudKit</string>
 	</array>
 	<key>com.apple.developer.ubiquity-container-identifiers</key>
 	<array>

--- a/VimIOS/VimView.swift
+++ b/VimIOS/VimView.swift
@@ -10,8 +10,8 @@ import UIKit
 import CoreText
 
 struct font{
-    static let name = "Menlo-Regular"
-    static let size =  CGFloat(14)
+    static let name = "Monaco"
+    static let size =  CGFloat(12)
 }
 
 struct FontProperties{
@@ -188,6 +188,7 @@ class VimView: UIView {
     
     func initFont() -> CTFont {
         let rawFont = CTFontCreateWithName(font.name as CFString, font.size, nil)
+        print(rawFont)
         
         var boundingRect = CGRect.zero;
         var glyph = CTFontGetGlyphWithName(rawFont, "0" as CFString)

--- a/VimIOS/VimView.swift
+++ b/VimIOS/VimView.swift
@@ -10,8 +10,8 @@ import UIKit
 import CoreText
 
 struct font{
-    static let name = "Monaco"
-    static let size =  CGFloat(12)
+    static let name = "Menlo"
+    static let size =  CGFloat(14)
 }
 
 struct FontProperties{
@@ -182,7 +182,7 @@ class VimView: UIView {
             
             
             dirtyRect = dirtyRect.union(rect);
-          //  print("Draw String \(s) at \(pos_x), \(pos_y) and \(dirtyRect)")
+            //print("Draw String \(s) at \(pos_x), \(pos_y) and \(dirtyRect)")
             
     }
     
@@ -191,7 +191,7 @@ class VimView: UIView {
         print(rawFont)
         
         var boundingRect = CGRect.zero;
-        var glyph = CTFontGetGlyphWithName(rawFont, "0" as CFString)
+        var glyph = CTFontGetGlyphWithName(rawFont, "w" as CFString)
        
         let glyphPointer = withUnsafePointer(to: &glyph) {(pointer: UnsafePointer<CGGlyph>) -> UnsafePointer<CGGlyph> in return pointer}
         
@@ -202,7 +202,8 @@ class VimView: UIView {
         
         char_ascent = CTFontGetAscent(rawFont)
         char_width = boundingRect.width
-        char_height = boundingRect.height+3
+        print("char width is ",char_width)
+        char_height = boundingRect.height * 2
 
 
         var advances = CGSize.zero

--- a/VimIOS/VimView.swift
+++ b/VimIOS/VimView.swift
@@ -51,6 +51,7 @@ class VimView: UIView {
         }
         //print("DrawRect \(rect)")
         
+        
         if( !rect.equalTo(CGRect.zero)) {
             let context = UIGraphicsGetCurrentContext()
             context!.saveGState()
@@ -202,7 +203,6 @@ class VimView: UIView {
         
         char_ascent = CTFontGetAscent(rawFont)
         char_width = boundingRect.width
-        print("char width is ",char_width)
         char_height = boundingRect.height * 2
 
 

--- a/VimIOS/VimView.swift
+++ b/VimIOS/VimView.swift
@@ -136,11 +136,11 @@ class VimView: UIView {
             }
     }
     
-    func drawString(_ s:NSAttributedString,
+    func drawString(_ s:String,
         font: CTFont,
-        pos_x:CGFloat,
-        pos_y: CGFloat,
-        rect:CGRect,
+        col:Int32,
+        row: Int32,
+        cells: Int32,
         p_antialias: Bool,
         transparent: Bool,
         cursor: Bool) {
@@ -152,36 +152,34 @@ class VimView: UIView {
             
             context.setCharacterSpacing(0);
             context.setTextDrawingMode(.fill)
-            
-            
+            let rect = CGRect(x: gui_fill_x(col), y: gui_fill_y(row), width: gui_fill_x(col+cells) - gui_fill_x(col) , height: gui_fill_y(row+1) - gui_fill_y(row))
             if(transparent) {
                 context.setFillColor(bgcolor!)
                 context.fill(rect)
             }
             
-            
             context.setFillColor(fgcolor!);
-//            let attributes : [String:AnyObject] = ([NSFontAttributeName:font, (kCTForegroundColorFromContextAttributeName as String):true])
-//            
-//            let attributesNeu = NSDictionary(dictionaryLiteral: (NSFontAttributeName, font) (kCTForegroundColorFromContextAttributeName, true))
-//            
-//            let attString = NSAttributedString(string: s as String, attributes: attributes)
-            
-            
-            let line = CTLineCreateWithAttributedString(s)
-            context.textPosition = CGPoint(x: pos_x, y: pos_y)
-            CTLineDraw(line, context)
-            
+            let attributes : [String:AnyObject] = ([NSFontAttributeName:font, (kCTForegroundColorFromContextAttributeName as String):true as AnyObject])
+            var index = 0
+            for i in s.characters.indices[s.startIndex..<s.endIndex]
+            {
+                let t = String(s[i])
+                let attString = NSAttributedString(string: t, attributes: attributes)
+                let line = CTLineCreateWithAttributedString(attString)
+                context.textPosition = CGPoint(x: gui_text_x(col+index), y: gui_text_y(row))
+                CTLineDraw(line, context)
+                index += (t.lengthOfBytes(using: .utf8) == 1 ? 1 : 2)
+            }
+//
+
+            //
             if(cursor) {
                 context.saveGState();
                 context.setBlendMode(.difference)
                 context.fill(rect)
                 context.restoreGState()
             }
-            
-            
-            
-            
+            //print(s)
             dirtyRect = dirtyRect.union(rect);
             //print("Draw String \(s) at \(pos_x), \(pos_y) and \(dirtyRect)")
             

--- a/VimIOS/VimViewController.swift
+++ b/VimIOS/VimViewController.swift
@@ -80,6 +80,9 @@ let special_keys: [[CChar]] = [
         [0,0, 0]
 ]
 
+let a_char = "a".utf8CString[0]
+let z_char = "z".utf8CString[0]
+
 
 
 class VimViewController: UIViewController, UIKeyInput, UITextInputTraits {
@@ -103,9 +106,9 @@ class VimViewController: UIViewController, UIKeyInput, UITextInputTraits {
     override var keyCommands: [UIKeyCommand]? {
         if let lang = self.view.window?.textInputMode?.primaryLanguage,
         lang == "zh-Hans",
+        State == 16,
         self.in_ime == true
         {
-            ime_input.becomeFirstResponder()
             return []
         }
         return keyCommandArray
@@ -115,11 +118,12 @@ class VimViewController: UIViewController, UIKeyInput, UITextInputTraits {
         if self.in_ime == true{
             if let result = ime_input.text
             {
+                ime_input.text = ""
                 insertText(result)
+                ime_input.isHidden = true
+                in_ime = false
             }
-            ime_input.isHidden = true
-            in_ime = false
-            ime_input.text = ""
+            
         }
     }
    // override var keyCommands:[UIKeyCommand]? { print("Show me the commands!"); return [UIKeyCommand(input:"[", modifierFlags:.Control, action:"keyPressed:")] }
@@ -138,7 +142,7 @@ class VimViewController: UIViewController, UIKeyInput, UITextInputTraits {
         vimView = VimView(frame: view.frame)
         vimView!.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         vimView?.addSubview(ime_input)
-        ime_input.frame = CGRect(x: 100, y: 100, width: 100, height: 15)
+        ime_input.frame = CGRect(x: 100, y: 100, width: 500, height: 15)
         ime_input.backgroundColor = .black
         ime_input.textColor = .white
         ime_input.isHidden = true
@@ -332,11 +336,15 @@ class VimViewController: UIViewController, UIKeyInput, UITextInputTraits {
     }
     
     func keyPressed(_ sender: UIKeyCommand) {
+        let value = sender.input.lowercased().utf8CString[0]
         if let lang = self.view.window?.textInputMode?.primaryLanguage,
+        value >= a_char && value <= z_char,
         in_ime == false,
+        State == 16,
         lang == "zh-Hans"{
             in_ime = true
             ime_input.isHidden = false
+            ime_input.becomeFirstResponder()
         }
         else
         {

--- a/VimIOS/VimViewController.swift
+++ b/VimIOS/VimViewController.swift
@@ -17,7 +17,7 @@ enum blink_state {
 
 
 //let hotkeys = "1234567890[]{}()!@#$%^&*/.,;"
-let hotkeys = "1234567890!@#$%^&*()_={}\\/.,<>?:|`~[]"
+let hotkeys = "1234567890!@#$%^&*()_={}\\/.,<>?:|`~[]'\""
 let shiftableHotkeys = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 let kMenuCommandModifiers = 0
@@ -291,6 +291,13 @@ class VimViewController: UIViewController, UIKeyInput, UITextInputTraits{
         return false
     }
     
+    func insertText(data: [UInt8]) {
+        becomeFirstResponder()
+        add_to_input_buf(data, Int32(data.count))
+        flush()
+        vimView?.setNeedsDisplay((vimView?.dirtyRect)!)
+    }
+    
     func insertText(_ text: String) {
         var escapeString = text.char
         if(text=="\n") {
@@ -307,7 +314,7 @@ class VimViewController: UIViewController, UIKeyInput, UITextInputTraits{
     }
     
     func deleteBackward() {
-            insertText(UnicodeScalar(Int(keyBS))!.description)
+        insertText(UnicodeScalar(Int(keyBS))!.description)
         
     }
     
@@ -365,9 +372,9 @@ class VimViewController: UIViewController, UIKeyInput, UITextInputTraits{
     func handleBarButton(_ sender: UIBarButtonItem) {
         switch sender.title! {
         case "ESC":
-            insertText(UnicodeScalar(Int(keyESC))!.description)
+            insertText( UnicodeScalar(Int(keyESC))!.description)
         case "TAB":
-            insertText(UnicodeScalar(Int(keyTAB))!.description)
+            insertText( UnicodeScalar(Int(keyTAB))!.description)
         case "Enter":
             if self.in_ime == true{
                 self.ime_on_enter_pressed(self)
@@ -476,14 +483,10 @@ class VimViewController: UIViewController, UIKeyInput, UITextInputTraits{
             }
         }
         if let k = key as? String{
-            insertText(k)
+            insertText( k)
         }
         else if let k = key as? [UInt8]{
-            becomeFirstResponder()
-            add_to_input_buf(k, Int32(k.count))
-            //print("called ",k)
-            flush()
-            vimView?.setNeedsDisplay((vimView?.dirtyRect)!)
+            insertText(data: k)
         }
         
     }
@@ -491,25 +494,12 @@ class VimViewController: UIViewController, UIKeyInput, UITextInputTraits{
 
     
     func waitForChars(_ wtime: Int) -> Int {
-     //   //print("Wait \(wtime)")
-        let passed = Date().timeIntervalSince(lastKeyPress)*1000
-        var wait = wtime
-        //print("Passed \(passed)")
-        
-        if(passed < 1000) {
-            wait = 10
-        } else if(wtime < 0 ){
-            wait = 4000
-        }
-        
-     
-     //print("Wait2 \(wait)")
-     
-     let expirationDate = Date(timeIntervalSinceNow: Double(wait)/1000.0)
-        RunLoop.current.acceptInput(forMode: RunLoopMode.defaultRunLoopMode, before: expirationDate)
+     let expirationDate = Date(timeIntervalSinceNow: Double(wtime)/1000.0)
+     RunLoop.current.acceptInput(forMode: RunLoopMode.defaultRunLoopMode, before: expirationDate)
+     RunLoop.current.run(until: Date.init(timeIntervalSinceNow: 0.01))
      let delay = expirationDate.timeIntervalSinceNow
-     return delay < 0 ? 0 : 1
-    
+     let result = delay < 0 ? 0 : 1
+     return result
     }
    
     
@@ -616,7 +606,7 @@ class VimViewController: UIViewController, UIKeyInput, UITextInputTraits{
             diffY += 1
         }
         while(diffY >= 1) {
-            insertText(UnicodeScalar(Int(getCTRLKeyCode("Y")))!.description)
+            insertText( UnicodeScalar(Int(getCTRLKeyCode("Y")))!.description)
             //gui_send_mouse_event(MOUSE_4, Int32(clickLocation.x), Int32(clickLocation.y), 0, 0);
             diffY -= 1
             

--- a/VimIOS/ios_prefix.h
+++ b/VimIOS/ios_prefix.h
@@ -20,6 +20,7 @@
 #define MACOS_X_UNIX 1
 #define ALWAYS_USE_GUI 1
 #define FEAT_GUI 1
+#define MULTI_BYTE 1
 #define FEAT_GUI_SCROLL_WHEEL_FORCE 1
 #define FEAT_GUI_IOS 1
 #define FEAT_BROWSE

--- a/vim/runtime/evim.vim
+++ b/vim/runtime/evim.vim
@@ -64,3 +64,4 @@ if has("autocmd")
 endif " has("autocmd")
 
 " vim: set sw=2 :
+

--- a/vim/src/gui_ios.m
+++ b/vim/src/gui_ios.m
@@ -366,6 +366,23 @@ gui_mch_clear_block(int row1, int col1, int row2, int col2)
    // gui_ios.dirtyRect = CGRectUnion(gui_ios.dirtyRect, rect);
 }
 
+CGFloat gui_fill_x(int col){
+    return FILL_X(col);
+}
+
+CGFloat gui_fill_y(int col){
+    return FILL_Y(col);
+}
+
+CGFloat gui_text_x(int col){
+    return TEXT_X(col);
+}
+
+CGFloat gui_text_y(int row){
+    return TEXT_Y(row);
+}
+
+
 
 void gui_mch_draw_string(int row, int col, char_u *s, int len, int flags) {
     if (s == NULL || len <= 0) {
@@ -373,25 +390,25 @@ void gui_mch_draw_string(int row, int col, char_u *s, int len, int flags) {
     }
 
     //NSLog(@"Draw %s ", s);
-    CGRect rect = CGRectMake(FILL_X(col),
-                             FILL_Y(row),
-                            #ifdef FEAT_MBYTE
-                            FILL_X(col+mb_string2cells(s,len))-FILL_X(col),
-                            #else
-                            FILL_X(col+len)-FILL_X(col),
-                            #endif
-                             FILL_Y(row+1)-FILL_Y(row));
+    //CGRect rect = CGRectMake(FILL_X(col),
+    //                         FILL_Y(row),
+    //                        #ifdef FEAT_MBYTE
+    //                        FILL_X(col+mb_string2cells(s,len))-FILL_X(col),
+    //                        #else
+    //                        FILL_X(col+len)-FILL_X(col),
+    //                        #endif
+    //                         FILL_Y(row+1)-FILL_Y(row));
     
     NSString * string = [[NSString alloc] initWithBytes:s length:len encoding:NSUTF8StringEncoding];
     if (string == nil) {
         return;
     }
-    NSDictionary * attributes = [[NSDictionary alloc] initWithObjectsAndKeys:(__bridge id)(gui.norm_font), (NSString *)kCTFontAttributeName,
-                                 [NSNumber numberWithBool:YES], kCTForegroundColorFromContextAttributeName,
-                                 nil];
-    NSAttributedString * attributedString = [[NSAttributedString alloc] initWithString:string attributes:attributes];
+    //NSDictionary * attributes = [[NSDictionary alloc] initWithObjectsAndKeys:(__bridge id)(gui.norm_font), (NSString *)kCTFontAttributeName,
+    //                             [NSNumber numberWithBool:YES], kCTForegroundColorFromContextAttributeName,
+    //                             nil];
+    //NSAttributedString * attributedString = [[NSAttributedString alloc] initWithString:string attributes:attributes];
     
-    [getView() drawString:attributedString font:gui.norm_font pos_x:TEXT_X(col) pos_y: TEXT_Y(row)  rect:rect p_antialias:true transparent: !(flags & DRAW_TRANSP) cursor: (flags & DRAW_CURSOR)];
+    [getView() drawString:string font:gui.norm_font col:col row: row cells: mb_string2cells(s,len) p_antialias:true transparent: !(flags & DRAW_TRANSP) cursor: (flags & DRAW_CURSOR)];
 
     //CGContextRef context = CGLayerGetContext(gui_ios.layer);
 

--- a/vim/src/gui_ios.m
+++ b/vim/src/gui_ios.m
@@ -1025,18 +1025,39 @@ gui_mch_mousehide(int hide)
     void
 clip_mch_request_selection(VimClipboard *cbd)
 {
+    NSLog(@"request");
 //    printf("%s\n",__func__);  
 }
 
     void
 clip_mch_set_selection(VimClipboard *cbd)
 {
-//    printf("%s\n",__func__);  
+    NSLog(@"set");
+    //printf("%s\n",__func__);  
+    long	scrapSize;
+    int		type;
+    char_u	*str = NULL;
+    if (!cbd->owned)
+        return;
+    clip_get_selection(cbd);
+
+    /*
+     * Once we set the clipboard, lose ownership.  If another application sets
+     * the clipboard, we don't want to think that we still own it.
+     */
+    cbd->owned = FALSE;
+    type = clip_convert_selection(&str, (long_u *)&scrapSize, cbd);
+    if (type >= 0)
+    {
+        [getViewController() handle_select: [NSString stringWithUTF8String:str]];
+    }
+    vim_free(str);
 }
 
    void
 clip_mch_lose_selection(VimClipboard *cbd)
 {
+    NSLog(@"lose");
 //    printf("%s\n",__func__);  
 }
 

--- a/vim/src/gui_ios.m
+++ b/vim/src/gui_ios.m
@@ -375,7 +375,11 @@ void gui_mch_draw_string(int row, int col, char_u *s, int len, int flags) {
     //NSLog(@"Draw %s ", s);
     CGRect rect = CGRectMake(FILL_X(col),
                              FILL_Y(row),
-                             FILL_X(col+len)-FILL_X(col),
+                            #ifdef FEAT_MBYTE
+                            FILL_X(col+mb_string2cells(s,len))-FILL_X(col),
+                            #else
+                            FILL_X(col+len)-FILL_X(col),
+                            #endif
                              FILL_Y(row+1)-FILL_Y(row));
     
     NSString * string = [[NSString alloc] initWithBytes:s length:len encoding:NSUTF8StringEncoding];

--- a/vim/src/gui_ios.m
+++ b/vim/src/gui_ios.m
@@ -1032,7 +1032,9 @@ clip_mch_request_selection(VimClipboard *cbd)
     void
 clip_mch_set_selection(VimClipboard *cbd)
 {
+
     NSLog(@"set");
+    NSLog(@"%d",State);
     //printf("%s\n",__func__);  
     long	scrapSize;
     int		type;

--- a/vim/src/gui_ios.m
+++ b/vim/src/gui_ios.m
@@ -263,6 +263,7 @@ gui_mch_update(void)
     // As a compromise we check for new input only every now and then. Note
     // that Cmd-. sends SIGINT so it has higher success rate at interrupting
     // Vim than Ctrl-C.
+    //    EventRecord theEvent;
 
 //    printf("%s\n",__func__);  
 }

--- a/vim/src/gui_ios.m
+++ b/vim/src/gui_ios.m
@@ -1029,7 +1029,16 @@ gui_mch_mousehide(int hide)
     void
 clip_mch_request_selection(VimClipboard *cbd)
 {
-    NSLog(@"request");
+	int type = MAUTO;
+    NSString *string = [getViewController() get_pasteboard_text: nil];
+    if(string){
+        char_u *str = (char_u*)[string UTF8String];
+        int len = [string lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+        if (str)
+        {
+            clip_yank_selection(type, str, len, cbd);
+        }
+    }
 //    printf("%s\n",__func__);  
 }
 
@@ -1595,3 +1604,4 @@ gui_mch_post_balloon(beval, mesg)
 }
 
 #endif // FEAT_BEVAL
+

--- a/vim/src/structs.h
+++ b/vim/src/structs.h
@@ -1198,7 +1198,7 @@ struct dictitem_S
 {
     typval_T	di_tv;		/* type and value of the variable */
     char_u	di_flags;	/* flags (only used for variable) */
-    char_u	di_key[30];	/* key (actually longer!)<- YOU FUCKERS! this used to be di_key[1] and broke vim with XCode 7.3 */
+    char_u	di_key[80];	/* key (actually longer!)<- YOU FUCKERS! this used to be di_key[1] and broke vim with XCode 7.3 */
 };
 
 typedef struct dictitem_S dictitem_T;


### PR DESCRIPTION
I've restructured part of code, now it supports wide-char display(akka FEAT_MBytes)
Also make some few changes to make it adapt to support chinese/japanese input methods(even it works a little bit cluncky on touchscreen mode which is not intend to)
now copy and paste should working as expected(from/to system clipboard).
I'm looking forward to add some supports to import/export vim configuration and plugin more conveniently,currently I have to use iExplorer to save/load, if possible we might try to use iCloud if possible?